### PR TITLE
Fix MapJoin filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For Java 11+ and Jakarta EE use a 2.x.x version:
 
 In the code, create an instance of OData class passing the Entity Bean Class. Set the Entity Manager and call <getAll> method or the <count> method passing the QueryOptions.
 
-```
+```java
 OData<Author> odata = new OData<Author>(Author.class);
 odata.setEntityManager(em);
 ...
@@ -62,7 +62,7 @@ odata.count(queryOptions);
 
   With this rest Endpoint:
 
-```
+```java
 @GET
 @Path("authors")
 @Produces(MediaType.APPLICATION_JSON)
@@ -92,7 +92,7 @@ You can see many examples in the [test classes](https://github.com/dometec/jaxrs
 
 Use a bean like this to marshialing the output data:
 
-```
+```java
 import java.util.Collection;
 
 import javax.json.bind.annotation.JsonbProperty;
@@ -114,22 +114,22 @@ public class ResultSet<T> {
 
 The rest method, with the logic to output also the total record count:
 
-```
-	@GET
-	@Path("authors")
-	@Produces(MediaType.APPLICATION_JSON)
-	public ResultSet<Author> authors(UriInfo info) {
+```java
+@GET
+@Path("authors")
+@Produces(MediaType.APPLICATION_JSON)
+public ResultSet<Author> authors(UriInfo info) {
 
-		QueryOptions queryOptions = QueryOptionsParser.from(info);
+	QueryOptions queryOptions = QueryOptionsParser.from(info);
 
-		OData<Author> odata = new OData<Author>(Author.class);
-		odata.setEntityManager(em);
-		ResultSet<Author> resultSet = new ResultSet<>();
-		resultSet.value = odata.getAll(queryOptions);
-		if (queryOptions.count)
-			resultSet.count = odata.countAll(queryOptions);
-		return resultSet;
-	}
+	OData<Author> odata = new OData<Author>(Author.class);
+	odata.setEntityManager(em);
+	ResultSet<Author> resultSet = new ResultSet<>();
+	resultSet.value = odata.getAll(queryOptions);
+	if (queryOptions.count)
+		resultSet.count = odata.countAll(queryOptions);
+	return resultSet;
+}
 ```
 
 ## Enrich Open API using Eclipse Microprofile
@@ -143,7 +143,7 @@ mp.openapi.filter=it.osys.jaxrsodata.ODataParamsFilter
 
 And add this class:
   
-```
+```java
 import java.util.ArrayList;
 
 import org.eclipse.microprofile.openapi.OASFactory;
@@ -235,7 +235,7 @@ public class ODataParamsFilter implements OASFilter {
   
 And annotate the method with **@Operation**. Remember to add "odata" in his summary.
 
-```
+```java
 ...
 import org.eclipse.microprofile.openapi.annotations.Operation;
 ...
@@ -252,7 +252,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 
 Add this annotation:
 
-```
+```java
 package it.osys.jaxrsodata;
 
 import java.lang.annotation.ElementType;
@@ -280,7 +280,7 @@ public @interface ODataImplicitParams {
 
 And add it to Endpoint:
 
-```
+```java
 @GET
 @Path("authors")
 @ODataImplicitParams

--- a/src/main/antlr4/it/osys/jaxrsodata/antlr4/ODataFilter.g4
+++ b/src/main/antlr4/it/osys/jaxrsodata/antlr4/ODataFilter.g4
@@ -90,7 +90,7 @@ GE: 'ge';
 LT: 'lt';
 LE: 'le';
 NUMBER: [0-9]+;
-FIELD: [A-Za-z0-9/]+;
+FIELD: [A-Za-z0-9/{}]+;
 
 
 WS: [ \t\r\n]+ -> skip;

--- a/src/test/java/it/osys/jaxrsodata/FilterTest.java
+++ b/src/test/java/it/osys/jaxrsodata/FilterTest.java
@@ -561,7 +561,7 @@ public class FilterTest extends HSQLDBInitialize {
 		Assert.assertEquals(1, result.size());
 		Assert.assertEquals(Long.valueOf(1), result.get(0).getId());
 	}
-	
+
 	@Test
 	public void testLengthInCollection1d() {
 		String filter = "length(ownerids) eq 1";
@@ -569,7 +569,7 @@ public class FilterTest extends HSQLDBInitialize {
 		Assert.assertEquals(1, result.size());
 		Assert.assertEquals(Long.valueOf(3), result.get(0).getId());
 	}
-	
+
 	@Test
 	public void testInOrHasString() {
 		String filter = "address/city in ('citta1', 'citta2') or ownerids has 3";
@@ -601,31 +601,30 @@ public class FilterTest extends HSQLDBInitialize {
 		Assert.assertEquals("DISTRIBUTION_NAME_UP", result.get(0).getStringType2());
 	}
 
-	/*
-	 * @Test public void getValueFieldOfMap() { String filter =
-	 * "name/value eq = 'Aplicación uno traductor'"; List<TestEntity> result =
-	 * getFilteredResults(filter); Assert.assertEquals(1, result.size());
-	 * Assert.assertEquals("distribution_name", result.get(0).getStringType2());
-	 * }
-	 */
+	@Test
+	public void getValueFieldOfMap() {
+		String filter = "name/{element} eq = 'Aplicación uno traductor'";
+		List<TestEntity> result = getFilteredResults(filter);
+		Assert.assertEquals(1, result.size());
+		Assert.assertEquals("distribution_name", result.get(0).getStringType2());
+	}
 
-	/*
-	 * @Test public void getKeyFieldOfMap() { String filter =
-	 * "name/key eq 'ES'"; List<TestEntity> result = getFilteredResults(filter);
-	 * Assert.assertEquals(2, result.size());
-	 * Assert.assertEquals("distribution_name", result.get(0).getStringType2());
-	 * Assert.assertEquals("DISTRIBUTION_NAME_UP",
-	 * result.get(1).getStringType2()); }
-	 */
+	@Test
+	public void getKeyFieldOfMap() {
+		String filter = "name/{index} eq 'ES'";
+		List<TestEntity> result = getFilteredResults(filter);
+		Assert.assertEquals(2, result.size());
+		Assert.assertEquals("distribution_name", result.get(0).getStringType2());
+		Assert.assertEquals("DISTRIBUTION_NAME_UP", result.get(1).getStringType2());
+	}
 
-	/*
-	 * @Test public void getKeyAndValueFieldOfMap() { String filter =
-	 * "name/key eq 'ES' and name/value eq = 'Aplicación uno traductor'";
-	 * List<TestEntity> result = getFilteredResults(filter);
-	 * Assert.assertEquals(1, result.size());
-	 * Assert.assertEquals("distribution_name", result.get(0).getStringType2());
-	 * }
-	 */
+	@Test
+	public void getKeyAndValueFieldOfMap() {
+		String filter = "name/{index} eq 'ES' and name/{element} eq = 'Aplicación uno traductor'";
+		List<TestEntity> result = getFilteredResults(filter);
+		Assert.assertEquals(1, result.size());
+		Assert.assertEquals("distribution_name", result.get(0).getStringType2());
+	}
 
 	@Test
 	public void throwExceptionWhenFilterEmpty() {


### PR DESCRIPTION
In newer versions of Hibernate, the code related to the MapJoin filter has changed.

The new sintaxes to use are:

- **field/{index}** for filter by map key
- **field/{element}** for filter by map value.